### PR TITLE
Allow cloudflare and ngrok hosts in vite server config

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -18,5 +18,10 @@ export default defineConfig({
         rewrite: (path) => path.replace(/^\/colyseus/, ''),
       },
     },
+    allowedHosts: [
+      '.trycloudflare.com',
+      '.ngrok-free.dev',
+      '.ngrok-free.app',
+    ],
   },
 });


### PR DESCRIPTION
When you visit randomly generated url without the host allowed, you just get a plain message that it isn't allowed. There is a hint to add the whole url to the config, but it isn't very convenient.

Just making it more frtictionless.